### PR TITLE
Add configurable sessionKey for CakeDC/Users compatibility

### DIFF
--- a/src/Controller/AuthTrait.php
+++ b/src/Controller/AuthTrait.php
@@ -14,8 +14,9 @@ trait AuthTrait {
 	 */
 	protected function userId() {
 		$userIdField = Configure::read('Favorites.userIdField') ?: 'id';
+		$sessionKey = Configure::read('Favorites.sessionKey') ?? 'Auth.User';
 
-		$uid = Configure::read('Auth.User.' . $userIdField);
+		$uid = Configure::read($sessionKey . '.' . $userIdField);
 		if ($uid) {
 			return $uid;
 		}
@@ -27,7 +28,7 @@ trait AuthTrait {
 			return $this->Auth->user($userIdField);
 		}
 
-		return $this->getRequest()->getSession()->read('Auth.User.' . $userIdField);
+		return $this->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 	}
 
 }

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -58,6 +58,7 @@ class FavoriteableComponent extends Component {
 	protected array $_defaultConfig = [
 		'on' => 'startup',
 		'userIdField' => 'id',
+		'sessionKey' => null, // Defaults to 'Auth.User', use 'Auth' for CakeDC/Users
 	];
 
 	/**
@@ -333,8 +334,9 @@ class FavoriteableComponent extends Component {
 	 */
 	protected function userId() {
 		$userIdField = Configure::read('Favorites.userIdField') ?: 'id';
+		$sessionKey = $this->getConfig('sessionKey') ?? Configure::read('Favorites.sessionKey') ?? 'Auth.User';
 
-		$uid = Configure::read('Auth.User.' . $userIdField);
+		$uid = Configure::read($sessionKey . '.' . $userIdField);
 		if ($uid) {
 			return $uid;
 		}
@@ -345,7 +347,7 @@ class FavoriteableComponent extends Component {
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
 			$userId = $this->Controller->Auth->user($userIdField);
 		} elseif (!$userId) {
-			$userId = $this->Controller->getRequest()->getSession()->read('Auth.User.' . $userIdField);
+			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 		}
 
 		return $userId;

--- a/src/Controller/Component/LikeableComponent.php
+++ b/src/Controller/Component/LikeableComponent.php
@@ -58,6 +58,7 @@ class LikeableComponent extends Component {
 		'on' => 'startup',
 		'userModelClass' => 'Users',
 		'userIdField' => 'id',
+		'sessionKey' => null, // Defaults to 'Auth.User', use 'Auth' for CakeDC/Users
 		'useEntity' => false,
 		'viewVariable' => null,
 	];
@@ -316,8 +317,9 @@ class LikeableComponent extends Component {
 	 */
 	protected function userId() {
 		$userIdField = Configure::read('Favorites.userIdField') ?: 'id';
+		$sessionKey = $this->getConfig('sessionKey') ?? Configure::read('Favorites.sessionKey') ?? 'Auth.User';
 
-		$uid = Configure::read('Auth.User.' . $userIdField);
+		$uid = Configure::read($sessionKey . '.' . $userIdField);
 		if ($uid) {
 			return $uid;
 		}
@@ -328,7 +330,7 @@ class LikeableComponent extends Component {
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
 			$userId = $this->Controller->Auth->user($userIdField);
 		} elseif (!$userId) {
-			$userId = $this->Controller->getRequest()->getSession()->read('Auth.User.' . $userIdField);
+			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 		}
 
 		return $userId;

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -58,6 +58,7 @@ class StarableComponent extends Component {
 		'on' => 'startup',
 		'userModelClass' => 'Users',
 		'userIdField' => 'id',
+		'sessionKey' => null, // Defaults to 'Auth.User', use 'Auth' for CakeDC/Users
 		'useEntity' => false,
 		'viewVariable' => null,
 	];
@@ -327,8 +328,9 @@ class StarableComponent extends Component {
 	 */
 	protected function userId() {
 		$userIdField = Configure::read('Favorites.userIdField') ?: 'id';
+		$sessionKey = $this->getConfig('sessionKey') ?? Configure::read('Favorites.sessionKey') ?? 'Auth.User';
 
-		$uid = Configure::read('Auth.User.' . $userIdField);
+		$uid = Configure::read($sessionKey . '.' . $userIdField);
 		if ($uid) {
 			return $uid;
 		}
@@ -339,7 +341,7 @@ class StarableComponent extends Component {
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
 			$userId = $this->Controller->Auth->user($userIdField);
 		} elseif (!$userId) {
-			$userId = $this->Controller->getRequest()->getSession()->read('Auth.User.' . $userIdField);
+			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 		}
 
 		return $userId;

--- a/src/View/Helper/AuthTrait.php
+++ b/src/View/Helper/AuthTrait.php
@@ -14,8 +14,9 @@ trait AuthTrait {
 	 */
 	protected function userId(): ?int {
 		$userIdField = Configure::read('Favorites.userIdField') ?: 'id';
+		$sessionKey = Configure::read('Favorites.sessionKey') ?? 'Auth.User';
 
-		$uid = Configure::read('Auth.User.' . $userIdField);
+		$uid = Configure::read($sessionKey . '.' . $userIdField);
 		if ($uid) {
 			return $uid;
 		}
@@ -26,7 +27,7 @@ trait AuthTrait {
 			return $view->AuthUser->user($userIdField);
 		}
 
-		return $view->getRequest()->getSession()->read('Auth.User.' . $userIdField);
+		return $view->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 	}
 
 }


### PR DESCRIPTION
## Summary

Adds configurable `sessionKey` for compatibility with CakeDC/Users and the modern CakePHP Authentication plugin.

By default, the plugin looks for user identity under `Auth.User` session key (legacy CakePHP Auth).
CakeDC/Users and the Authentication plugin store identity under `Auth` directly.

**Files updated:**
- `src/Controller/AuthTrait.php`
- `src/View/Helper/AuthTrait.php`
- `src/Controller/Component/LikeableComponent.php`
- `src/Controller/Component/StarableComponent.php`
- `src/Controller/Component/FavoriteableComponent.php`

## Configuration

Add to `config/app.php`:

```php
'Favorites' => [
    'sessionKey' => 'Auth', // For CakeDC/Users or Authentication plugin
    // 'sessionKey' => 'Auth.User', // Default (legacy Auth)
],
```

Or configure per-component:

```php
$this->loadComponent('Favorites.Likeable', [
    'sessionKey' => 'Auth',
]);
```

## Test plan

- [ ] Verify user ID is correctly read with default `Auth.User` session key
- [ ] Verify user ID is correctly read with `Auth` session key (CakeDC/Users)