### PR TITLE
Fix CakePHP 5.3 behavior method call deprecations

### DIFF
--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -321,7 +321,9 @@ class FavoriteableComponent extends Component {
 		];
 		$action = $data['action'] === 'remove' ? 'removeFavorite' : 'addFavorite';
 
-		$result = $this->Controller->{$this->modelAlias}->$action($options);
+		/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
+		$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
+		$result = $behavior->$action($options);
 		if ($result === null) {
 			$this->Flash->error(__d('favorites', 'An error occurred.'));
 		}
@@ -434,7 +436,9 @@ class FavoriteableComponent extends Component {
 				'modelId' => $modelId,
 				'modelName' => $modelName,
 			];
-			$result = $this->Controller->{$this->modelAlias}->addFavorite($options);
+			/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
+			$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
+			$result = $behavior->addFavorite($options);
 
 			if ($result !== null) {
 				if ($result) {

--- a/src/Controller/Component/LikeableComponent.php
+++ b/src/Controller/Component/LikeableComponent.php
@@ -283,14 +283,14 @@ class LikeableComponent extends Component {
 		];
 		$action = $this->action($data['action']);
 
-		/** @var \Favorites\Model\Behavior\LikeableBehavior $table */
-		$table = $this->Controller->{$this->modelAlias};
 		/**
 		 * @uses \Favorites\Model\Behavior\LikeableBehavior::addLike()
 		 * @uses \Favorites\Model\Behavior\LikeableBehavior::addDislike()
 		 * @uses \Favorites\Model\Behavior\LikeableBehavior::remove()
 		 */
-		$result = $table->$action($options);
+		/** @var \Favorites\Model\Behavior\LikeableBehavior $behavior */
+		$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Likeable');
+		$result = $behavior->$action($options);
 		if ($result === null) {
 			$this->Flash->error(__d('favorites', 'An error occurred.'));
 		}

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -295,13 +295,13 @@ class StarableComponent extends Component {
 		];
 		$action = $data['action'] === 'unstar' ? 'removeStar' : 'addStar';
 
-		/** @var \Favorites\Model\Behavior\StarableBehavior $table */
-		$table = $this->Controller->{$this->modelAlias};
 		/**
 		 * @uses \Favorites\Model\Behavior\StarableBehavior::addStar()
 		 * @uses \Favorites\Model\Behavior\StarableBehavior::removeStar()
 		 */
-		$result = $table->$action($options);
+		/** @var \Favorites\Model\Behavior\StarableBehavior $behavior */
+		$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Starable');
+		$result = $behavior->$action($options);
 		if ($result === null) {
 			$this->Flash->error(__d('favorites', 'An error occurred.'));
 		}

--- a/tests/TestCase/Model/Behavior/FavoriteableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/FavoriteableBehaviorTest.php
@@ -54,7 +54,9 @@ class FavoriteableBehaviorTest extends TestCase {
 			'modelId' => 1,
 			'userId' => 1,
 		];
-		$result = $this->table->addFavorite($options);
+		/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Favoriteable');
+		$result = $behavior->addFavorite($options);
 
 		/** @var \Favorites\Model\Entity\Favorite $favorite */
 		$favorite = $this->table->Favorites->get($result);
@@ -73,7 +75,9 @@ class FavoriteableBehaviorTest extends TestCase {
 			'modelId' => 1,
 			'userId' => 1,
 		];
-		$result = $this->table->removeFavorite($options);
+		/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Favoriteable');
+		$result = $behavior->removeFavorite($options);
 		$this->assertSame(1, $result);
 
 		$favorites = $this->table->Favorites->find()->all()->toArray();

--- a/tests/TestCase/Model/Behavior/LikeableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LikeableBehaviorTest.php
@@ -54,7 +54,9 @@ class LikeableBehaviorTest extends TestCase {
 			'modelId' => 1,
 			'userId' => 1,
 		];
-		$result = $this->table->addLike($options);
+		/** @var \Favorites\Model\Behavior\LikeableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Likeable');
+		$result = $behavior->addLike($options);
 
 		/** @var \Favorites\Model\Entity\Favorite $favorite */
 		$favorite = $this->table->Favorites->get($result);
@@ -73,7 +75,9 @@ class LikeableBehaviorTest extends TestCase {
 			'modelId' => 1,
 			'userId' => 1,
 		];
-		$result = $this->table->addDislike($options);
+		/** @var \Favorites\Model\Behavior\LikeableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Likeable');
+		$result = $behavior->addDislike($options);
 
 		/** @var \Favorites\Model\Entity\Favorite $favorite */
 		$favorite = $this->table->Favorites->get($result);

--- a/tests/TestCase/Model/Behavior/StarableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StarableBehaviorTest.php
@@ -53,7 +53,9 @@ class StarableBehaviorTest extends TestCase {
 			'modelId' => 1,
 			'userId' => 1,
 		];
-		$result = $this->table->addStar($options);
+		/** @var \Favorites\Model\Behavior\StarableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Starable');
+		$result = $behavior->addStar($options);
 
 		/** @var \Favorites\Model\Entity\Favorite $favorite */
 		$favorite = $this->table->Favorites->get($result);
@@ -72,7 +74,9 @@ class StarableBehaviorTest extends TestCase {
 			'modelId' => 1,
 			'userId' => 1,
 		];
-		$result = $this->table->removeStar($options);
+		/** @var \Favorites\Model\Behavior\StarableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Starable');
+		$result = $behavior->removeStar($options);
 		$this->assertSame(1, $result);
 
 		$favorites = $this->table->Favorites->find()->all()->toArray();

--- a/tests/TestCase/Model/CounterCacheTest.php
+++ b/tests/TestCase/Model/CounterCacheTest.php
@@ -54,13 +54,15 @@ class CounterCacheTest extends TestCase {
 
 		$post = $this->table->find()->firstOrFail();
 
-		$this->table->addStar(['modelId' => $post->id, 'userId' => 1]);
+		/** @var \Favorites\Model\Behavior\StarableBehavior $behavior */
+		$behavior = $this->table->getBehavior('Starable');
+		$behavior->addStar(['modelId' => $post->id, 'userId' => 1]);
 
 		$user = $this->getTableLocator()->get('Users')->newEntity([
 			'name' => '2nd',
 		]);
 		$this->getTableLocator()->get('Users')->saveOrFail($user);
-		$this->table->addStar(['modelId' => $post->id, 'userId' => $user->id]);
+		$behavior->addStar(['modelId' => $post->id, 'userId' => $user->id]);
 
 		$post = $this->table->find()
 			->find('starred')


### PR DESCRIPTION
## Summary
- Use `$table->getBehavior('BehaviorName')->methodName()` instead of calling behavior methods directly on the table instance
- Updated FavoriteableComponent to use getBehavior() for addFavorite/removeFavorite
- Updated LikeableComponent to use getBehavior() for addLike/addDislike  
- Updated StarableComponent to use getBehavior() for addStar/removeStar
- Updated all behavior tests to follow the same pattern

This fixes the CakePHP 5.3 deprecation: "Calling behavior methods on the table instance is deprecated"