### PR TITLE
Add tests for Config and LikesHelper classes

### DIFF
--- a/tests/TestCase/Utility/ConfigTest.php
+++ b/tests/TestCase/Utility/ConfigTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Favorites\Test\TestCase\Utility;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Favorites\Utility\Config;
+use InvalidArgumentException;
+
+/**
+ * @uses \Favorites\Utility\Config
+ */
+class ConfigTest extends TestCase {
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Configure::delete('Favorites.models');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test type constants
+	 *
+	 * @return void
+	 */
+	public function testTypeConstants(): void {
+		$this->assertSame('star', Config::TYPE_STAR);
+		$this->assertSame('like', Config::TYPE_LIKE);
+		$this->assertSame('favorite', Config::TYPE_FAVORITE);
+	}
+
+	/**
+	 * Test strategy constants
+	 *
+	 * @return void
+	 */
+	public function testStrategyConstants(): void {
+		$this->assertSame('controller', Config::STRATEGY_CONTROLLER);
+		$this->assertSame('action', Config::STRATEGY_ACTION);
+	}
+
+	/**
+	 * Test strategy with valid controller strategy
+	 *
+	 * @return void
+	 */
+	public function testStrategyWithController(): void {
+		$result = Config::strategy(Config::STRATEGY_CONTROLLER);
+		$this->assertSame('controller', $result);
+	}
+
+	/**
+	 * Test strategy with valid action strategy
+	 *
+	 * @return void
+	 */
+	public function testStrategyWithAction(): void {
+		$result = Config::strategy(Config::STRATEGY_ACTION);
+		$this->assertSame('action', $result);
+	}
+
+	/**
+	 * Test strategy with invalid value throws exception
+	 *
+	 * @return void
+	 */
+	public function testStrategyWithInvalidValue(): void {
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid strategy invalid');
+
+		Config::strategy('invalid');
+	}
+
+	/**
+	 * Test alias finds model key from config
+	 *
+	 * @return void
+	 */
+	public function testAlias(): void {
+		Configure::write('Favorites.models', [
+			'Posts' => 'Blog.Posts',
+			'Articles' => 'App.Articles',
+		]);
+
+		$result = Config::alias('Blog.Posts', Config::TYPE_FAVORITE);
+		$this->assertSame('Posts', $result);
+
+		$result = Config::alias('App.Articles', Config::TYPE_FAVORITE);
+		$this->assertSame('Articles', $result);
+	}
+
+	/**
+	 * Test alias returns null for non-existent model
+	 *
+	 * @return void
+	 */
+	public function testAliasNotFound(): void {
+		Configure::write('Favorites.models', [
+			'Posts' => 'Blog.Posts',
+		]);
+
+		$result = Config::alias('NonExistent', Config::TYPE_FAVORITE);
+		$this->assertNull($result);
+	}
+
+	/**
+	 * Test models returns config models
+	 *
+	 * @return void
+	 */
+	public function testModels(): void {
+		Configure::write('Favorites.models', [
+			'Posts' => 'Blog.Posts',
+			'Articles' => 'App.Articles',
+		]);
+
+		$result = Config::models(Config::TYPE_FAVORITE);
+		$this->assertArrayHasKey('Posts', $result);
+		$this->assertArrayHasKey('Articles', $result);
+	}
+
+	/**
+	 * Test models returns empty array when not configured
+	 *
+	 * @return void
+	 */
+	public function testModelsEmpty(): void {
+		Configure::delete('Favorites.models');
+
+		$result = Config::models(Config::TYPE_FAVORITE);
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test models with type-specific config
+	 *
+	 * @return void
+	 */
+	public function testModelsWithTypeSpecific(): void {
+		Configure::write('Favorites.models', [
+			Config::TYPE_STAR => [
+				'StarPosts' => 'Blog.Posts',
+			],
+			'GeneralPosts' => 'App.Posts',
+		]);
+
+		$result = Config::models(Config::TYPE_STAR);
+		$this->assertArrayHasKey('StarPosts', $result);
+		$this->assertArrayHasKey('GeneralPosts', $result);
+	}
+
+}

--- a/tests/TestCase/View/Helper/LikesHelperTest.php
+++ b/tests/TestCase/View/Helper/LikesHelperTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Favorites\Test\TestCase\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\RouteBuilder;
+use Cake\Routing\Router;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Favorites\View\Helper\LikesHelper;
+
+/**
+ * @uses \Favorites\View\Helper\LikesHelper
+ */
+class LikesHelperTest extends TestCase {
+
+	/**
+	 * @var \Favorites\View\Helper\LikesHelper
+	 */
+	protected LikesHelper $Likes;
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Router::createRouteBuilder('/')->scope('/', function (RouteBuilder $routes) {
+			$routes->setRouteClass(DashedRoute::class);
+			$routes->plugin('Favorites', ['path' => '/favorites'], function (RouteBuilder $builder) {
+				$builder->fallbacks();
+			});
+		});
+
+		$view = new View();
+		$this->Likes = new LikesHelper($view);
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset($this->Likes);
+		Configure::delete('Favorites');
+		Router::reload();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test HTML type constants
+	 *
+	 * @return void
+	 */
+	public function testHtmlTypeConstants(): void {
+		$this->assertSame(0, LikesHelper::HTML_TYPE_UTF8);
+		$this->assertSame(1, LikesHelper::HTML_TYPE_FA6);
+	}
+
+	/**
+	 * Test initialize with default UTF8 icons
+	 *
+	 * @return void
+	 */
+	public function testInitializeDefaultIcons(): void {
+		$html = $this->Likes->getConfig('html');
+		$this->assertIsArray($html);
+		$this->assertSame('👍', $html[1]);
+		$this->assertSame('👎', $html[-1]);
+		$this->assertSame('❌', $html[0]);
+	}
+
+	/**
+	 * Test initialize with FA6 icons
+	 *
+	 * @return void
+	 */
+	public function testInitializeWithFa6Icons(): void {
+		$view = new View();
+		$helper = new LikesHelper($view, ['html' => LikesHelper::HTML_TYPE_FA6]);
+
+		$html = $helper->getConfig('html');
+		$this->assertIsArray($html);
+		$this->assertStringContainsString('fa-arrow-up', $html[1]);
+		$this->assertStringContainsString('fa-arrow-down', $html[-1]);
+		$this->assertStringContainsString('fa-remove', $html[0]);
+	}
+
+	/**
+	 * Test urlLike generates correct URL
+	 *
+	 * @return void
+	 */
+	public function testUrlLike(): void {
+		$url = $this->Likes->urlLike('Posts', 123);
+		$this->assertStringContainsString('/favorites/likes/like/Posts/123', $url);
+	}
+
+	/**
+	 * Test urlDislike generates correct URL
+	 *
+	 * @return void
+	 */
+	public function testUrlDislike(): void {
+		$url = $this->Likes->urlDislike('Posts', 456);
+		$this->assertStringContainsString('/favorites/likes/dislike/Posts/456', $url);
+	}
+
+	/**
+	 * Test icon returns correct HTML for like value
+	 *
+	 * @return void
+	 */
+	public function testIconLike(): void {
+		$icon = $this->Likes->icon('Posts', 1, 1);
+		$this->assertSame('👍', $icon);
+	}
+
+	/**
+	 * Test icon returns correct HTML for dislike value
+	 *
+	 * @return void
+	 */
+	public function testIconDislike(): void {
+		$icon = $this->Likes->icon('Posts', 1, -1);
+		$this->assertSame('👎', $icon);
+	}
+
+	/**
+	 * Test icon returns correct HTML for remove/reset value
+	 *
+	 * @return void
+	 */
+	public function testIconRemove(): void {
+		$icon = $this->Likes->icon('Posts', 1, 0);
+		$this->assertSame('❌', $icon);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add ConfigTest: tests for strategy validation, alias lookup, models config with type-specific settings
- Add LikesHelperTest: tests for HTML type constants, icon initialization (UTF8 and FA6), URL generation for like/dislike, icon rendering

This improves test coverage by testing previously uncovered utility and helper classes.