### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/Favorites/index.php
+++ b/templates/Admin/Favorites/index.php
@@ -3,6 +3,7 @@
  * @var \App\View\AppView $this
  * @var array<string, int> $models
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
@@ -18,7 +19,13 @@
     <ul>
 		<?php foreach ($models as $model => $count): ?>
 		<li>
-			<?php echo h($model); ?>: <?php echo $count; ?>x <?php echo $this->Form->postLink('Reset', ['?' => ['model' => $model]], ['confirm' => 'Sure?']); ?>
+			<?php echo h($model); ?>: <?php echo $count; ?>x <?php echo $this->Form->postButton('Reset', ['?' => ['model' => $model]], [
+				'class' => 'btn btn-link btn-sm p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]); ?>
 		</li>
 		<?php endforeach; ?>
 	</ul>
@@ -26,3 +33,12 @@
 	<p><?= $this->Html->link(__('Details'), ['action' => 'listing'], ['class' => '']) ?></p>
 
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>

--- a/templates/Admin/Favorites/listing.php
+++ b/templates/Admin/Favorites/listing.php
@@ -3,6 +3,7 @@
  * @var \App\View\AppView $this
  * @var iterable<\Favorites\Model\Entity\Favorite> $favorites
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
@@ -44,7 +45,14 @@
 						if ($this->helpers()->has('Icon')) {
 							$label = $this->Icon->render('delete');
 						}
-						echo $this->Form->postLink($label, ['action' => 'delete', $comment->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $comment->id)]);
+						echo $this->Form->postButton($label, ['action' => 'delete', $comment->id], [
+							'escapeTitle' => false,
+							'class' => 'btn btn-link p-0 align-baseline',
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+							],
+						]);
 						?>
                     </td>
                 </tr>
@@ -55,3 +63,12 @@
 
     <?php echo $this->element('Favorites.pagination'); ?>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>


### PR DESCRIPTION
## Summary

- Replace `Form->postLink` + `confirm` with `Form->postButton` + `data-confirm-message` in the two admin templates.
- Add nonce-aware inline `<script>` blocks that delegate confirmation handling via `form[data-confirm-message]`.

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- Replace 2 `Form->postLink` calls with `Form->postButton` (preserves the confirmation UX via `form[data-confirm-message]` + a JS delegate).
- Add 2 inline `<script>` blocks with `nonce` (one per admin template) that attach the delegated `submit` listener.

The plugin has no dedicated layout, so the delegate lives in the individual admin templates that actually render `postButton` forms.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink('Reset', ['?' => ['model' => $model]], ['confirm' => 'Sure?']) ?>
+ <?= $this->Form->postButton('Reset', ['?' => ['model' => $model]], [
+     'class' => 'btn btn-link btn-sm p-0 align-baseline',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => 'Sure?',
+     ],
+ ]) ?>
```
