### PR TITLE
Add admin access gate; lock down Favorite entity; harden components

### DIFF
--- a/src/Controller/Admin/FavoritesController.php
+++ b/src/Controller/Admin/FavoritesController.php
@@ -4,12 +4,74 @@ declare(strict_types=1);
 namespace Favorites\Controller\Admin;
 
 use App\Controller\AppController;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\Response;
+use Cake\Log\Log;
+use Closure;
+use Throwable;
 
 /**
+ * Admin namespace for the Favorites plugin.
+ *
+ * The default policy is **deny**: the host application MUST set
+ * `Favorites.adminAccess` to a `Closure` that receives the current request
+ * and returns literal `true` to grant access. Anything else (unset,
+ * non-Closure, returns false, returns a truthy non-bool, or throws) yields
+ * a 403. (Issue #4 — patterned after Queue.adminAccess.)
+ *
+ * ```php
+ * Configure::write('Favorites.adminAccess', function (\Cake\Http\ServerRequest $request): bool {
+ *     $identity = $request->getAttribute('identity');
+ *     return $identity !== null && in_array('admin', (array)$identity->roles, true);
+ * });
+ * ```
+ *
  * @property \Favorites\Model\Table\FavoritesTable $Favorites
  * @method \Favorites\Model\Entity\Favorite[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
 class FavoritesController extends AppController {
+
+	/**
+	 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+	 *
+	 * @throws \Cake\Http\Exception\ForbiddenException When access is denied or unconfigured.
+	 *
+	 * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		// Coexist with cakephp/authorization: the gate IS the authorization decision
+		// for these controllers, so silence the policy check.
+		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+			$this->components()->get('Authorization')->skipAuthorization();
+		}
+
+		$gate = Configure::read('Favorites.adminAccess');
+		if (!($gate instanceof Closure)) {
+			throw new ForbiddenException(__d(
+				'favorites',
+				'Favorites admin backend is not configured. Set Favorites.adminAccess to a Closure that returns true for permitted callers.',
+			));
+		}
+
+		try {
+			$allowed = $gate($this->request) === true;
+		} catch (ForbiddenException $e) {
+			throw $e;
+		} catch (Throwable $e) {
+			Log::warning(sprintf('Favorites.adminAccess threw %s: %s', $e::class, $e->getMessage()));
+
+			throw new ForbiddenException(__d('favorites', 'Favorites admin access denied.'));
+		}
+
+		if (!$allowed) {
+			throw new ForbiddenException(__d('favorites', 'Favorites admin access denied.'));
+		}
+	}
 
 	/**
 	 * @return \Cake\Http\Response|null|void Renders view
@@ -17,8 +79,15 @@ class FavoritesController extends AppController {
 	public function index() {
 		if ($this->request->is(['post', 'put'])) {
 			$model = $this->request->getQuery('model');
+			// Whitelist against `Favorites.models` — without this, `reset()` happily issues
+			// `DELETE FROM favorites_favorites WHERE model = ''` for unmapped values, and the
+			// query parameter would pollute the i18n cache when concatenated into __() (Issue #3).
+			$allowed = array_keys((array)Configure::read('Favorites.models'));
+			if (!is_string($model) || !in_array($model, $allowed, true)) {
+				throw new BadRequestException('Invalid model');
+			}
 			$count = $this->Favorites->reset($model);
-			$this->Flash->success(__('The favorites have been reset for `' . $model . '`, deleted: ' . $count . '.'));
+			$this->Flash->success(__('The favorites have been reset for `{0}`, deleted: {1}.', $model, $count));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -49,7 +118,7 @@ class FavoritesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
-	public function delete($id = null) {
+	public function delete(?string $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 		$favorite = $this->Favorites->get($id);
 		if ($this->Favorites->delete($favorite)) {

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -41,6 +41,7 @@ use BadMethodCallException;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Utility\Inflector;
 use RuntimeException;
@@ -307,19 +308,30 @@ class FavoriteableComponent extends Component {
 		/** @var \Cake\Datasource\EntityInterface $entity */
 		$entity = $this->Controller->viewBuilder()->getVar($this->viewVariable);
 
+		// Validate the request shape up front (Issue #5). `alias` and `action` are required.
+		$alias = $data['alias'] ?? null;
+		$actionName = $data['action'] ?? null;
+		if (!is_string($alias) || !is_string($actionName)) {
+			throw new BadRequestException('Missing favorite payload');
+		}
+
 		if ($this->getConfig('useEntity')) {
 			$modelId = $entity->get('id');
 		} else {
 			$modelId = $data['id'] ?? null;
+			if (!$modelId) {
+				throw new BadRequestException('Missing favorite payload');
+			}
 		}
 
+		$rawValue = $data['value'] ?? null;
 		$options = [
 			'userId' => $this->userId(),
 			'modelId' => $modelId,
-			'model' => $data['alias'],
-			'value' => $data['value'] !== null ? (int)$data['value'] : null,
+			'model' => $alias,
+			'value' => $rawValue !== null ? (int)$rawValue : null,
 		];
-		$action = $data['action'] === 'remove' ? 'removeFavorite' : 'addFavorite';
+		$action = $actionName === 'remove' ? 'removeFavorite' : 'addFavorite';
 
 		/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
 		$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
@@ -484,10 +496,19 @@ class FavoriteableComponent extends Component {
 	 * @return void
 	 */
 	public function callbackToggle($modelId, $favoriteId) {
-		if (
-			!isset($this->Controller->passedArgs['favorite_action'])
-			|| !($this->Controller->passedArgs['favorite_action'] == 'toggle_approve' && $this->Controller->Auth->user('is_admin') == true)
-		) {
+		// Modernised admin gate (Issue #6): `passedArgs` is the deprecated CakePHP 2.x property
+		// and is not populated on Cake 5 controllers; reading it would raise an undefined
+		// property notice. Use the typed request accessors and strict comparisons so
+		// non-bool truthy values from custom auth backends (`'admin'`, `'true'`, ...)
+		// can't slip past as `is_admin == true`.
+		$action = (string)$this->Controller->getRequest()->getQuery('favorite_action', '');
+		$user = $this->Controller->Auth ?? null;
+		$isAdmin = false;
+		if ($user !== null) {
+			$flag = $user->user('is_admin');
+			$isAdmin = $flag === true || $flag === 1 || $flag === '1';
+		}
+		if ($action !== 'toggle_approve' || !$isAdmin) {
 			throw new MethodNotAllowedException(__d('favorites', 'Nonrestricted operation'));
 		}
 		if ($this->Controller->{$this->modelAlias}->favoriteToggle($favoriteId)) {

--- a/src/Controller/Component/LikeableComponent.php
+++ b/src/Controller/Component/LikeableComponent.php
@@ -41,6 +41,7 @@ use BadMethodCallException;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Utility\Inflector;
 
@@ -270,18 +271,31 @@ class LikeableComponent extends Component {
 		/** @var \Cake\Datasource\EntityInterface $entity */
 		$entity = $this->Controller->viewBuilder()->getVar($this->viewVariable);
 
+		// Validate the request shape up front (Issue #5). Both `id` (when not derived from
+		// the entity), `alias`, and `action` are required; missing keys would otherwise
+		// raise an `Undefined array key` warning on every malformed POST and bubble
+		// `BadMethodCallException` from $this->action().
+		$alias = $data['alias'] ?? null;
+		$actionName = $data['action'] ?? null;
+		if (!is_string($alias) || !is_string($actionName)) {
+			throw new BadRequestException('Missing favorite payload');
+		}
+
 		if ($this->getConfig('useEntity')) {
 			$modelId = $entity->get('id');
 		} else {
-			$modelId = $data['id'];
+			$modelId = $data['id'] ?? null;
+			if (!$modelId) {
+				throw new BadRequestException('Missing favorite payload');
+			}
 		}
 
 		$options = [
 			'userId' => $this->userId(),
 			'modelId' => $modelId,
-			'model' => $data['alias'],
+			'model' => $alias,
 		];
-		$action = $this->action($data['action']);
+		$action = $this->action($actionName);
 
 		/**
 		 * @uses \Favorites\Model\Behavior\LikeableBehavior::addLike()

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -41,6 +41,7 @@ use BadMethodCallException;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Utility\Inflector;
 
@@ -282,18 +283,28 @@ class StarableComponent extends Component {
 		/** @var \Cake\Datasource\EntityInterface $entity */
 		$entity = $this->Controller->viewBuilder()->getVar($this->viewVariable);
 
+		// Validate the request shape up front (Issue #5).
+		$alias = $data['alias'] ?? null;
+		$actionName = $data['action'] ?? null;
+		if (!is_string($alias) || !is_string($actionName)) {
+			throw new BadRequestException('Missing favorite payload');
+		}
+
 		if ($this->getConfig('useEntity')) {
 			$modelId = $entity->get('id');
 		} else {
-			$modelId = $data['id'];
+			$modelId = $data['id'] ?? null;
+			if (!$modelId) {
+				throw new BadRequestException('Missing favorite payload');
+			}
 		}
 
 		$options = [
 			'userId' => $this->userId(),
 			'modelId' => $modelId,
-			'model' => $data['alias'],
+			'model' => $alias,
 		];
-		$action = $data['action'] === 'unstar' ? 'removeStar' : 'addStar';
+		$action = $actionName === 'unstar' ? 'removeStar' : 'addStar';
 
 		/**
 		 * @uses \Favorites\Model\Behavior\StarableBehavior::addStar()

--- a/src/Controller/FavoritesController.php
+++ b/src/Controller/FavoritesController.php
@@ -6,6 +6,7 @@ use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Http\Response;
 use InvalidArgumentException;
 use TinyAuth\Controller\Component\AuthComponent;
 use TinyAuth\Controller\Component\AuthUserComponent;
@@ -40,7 +41,7 @@ class FavoritesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function add($alias = null, $id = null) {
+	public function add(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'put', 'patch']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -77,7 +78,7 @@ class FavoritesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function remove($alias = null, $id = null) {
+	public function remove(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -102,7 +103,7 @@ class FavoritesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function delete($id = null) {
+	public function delete(?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 
 		$id = $this->request->getData('id') ?: $id;

--- a/src/Controller/LikesController.php
+++ b/src/Controller/LikesController.php
@@ -6,6 +6,7 @@ use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Http\Response;
 use TinyAuth\Controller\Component\AuthComponent;
 use TinyAuth\Controller\Component\AuthUserComponent;
 
@@ -39,7 +40,7 @@ class LikesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function like($alias = null, $id = null) {
+	public function like(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'put', 'patch']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -68,7 +69,7 @@ class LikesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function dislike($alias = null, $id = null) {
+	public function dislike(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'put', 'patch']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -84,7 +85,9 @@ class LikesController extends AppController {
 		}
 
 		$result = $this->Favorites->add($model, $entity->get('id'), $uid, -1);
-		if (!$result->isNew()) {
+		// `isNew()` is true for unsaved entities — that IS the failure case (Issue #1).
+		// Flash an error only when persistence actually didn't happen.
+		if ($result->isNew()) {
 			$this->Flash->error(__d('favorites', 'Could not save dislike, please try again.'));
 		}
 
@@ -97,7 +100,7 @@ class LikesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function remove($alias = null, $id = null) {
+	public function remove(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -122,7 +125,7 @@ class LikesController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function delete($id = null) {
+	public function delete(?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 
 		$id = $this->request->getData('id') ?: $id;

--- a/src/Controller/StarsController.php
+++ b/src/Controller/StarsController.php
@@ -6,6 +6,7 @@ use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Http\Response;
 use TinyAuth\Controller\Component\AuthComponent;
 use TinyAuth\Controller\Component\AuthUserComponent;
 
@@ -39,7 +40,7 @@ class StarsController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function star($alias = null, $id = null) {
+	public function star(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'put', 'patch']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -68,7 +69,7 @@ class StarsController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function unstar($alias = null, $id = null) {
+	public function unstar(?string $alias = null, ?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 
 		$model = Configure::read('Favorites.models.' . $alias);
@@ -93,7 +94,7 @@ class StarsController extends AppController {
 	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function delete($id = null) {
+	public function delete(?int $id = null): ?Response {
 		$this->request->allowMethod(['post', 'delete']);
 
 		$id = $this->request->getData('id') ?: $id;

--- a/src/Model/Entity/Favorite.php
+++ b/src/Model/Entity/Favorite.php
@@ -16,17 +16,25 @@ use Cake\ORM\Entity;
 class Favorite extends Entity {
 
 	/**
-	 * Fields that can be mass assigned using newEntity() or patchEntity().
+	 * Fields that can be mass assigned via patchEntity() / newEntity().
 	 *
-	 * Note that when '*' is set to true, this allows all unspecified fields to
-	 * be mass assigned. For security purposes, it is advised to set '*' to false
-	 * (or remove it), and explicitly make individual fields accessible as needed.
+	 * Foreign keys (`user_id`, `model`, `foreign_key`) and `created` are explicitly NOT
+	 * mass-assignable — letting them through would allow a host application that ever exposes
+	 * a Favorite-shaped CRUD endpoint, fixture factory, or admin form to forge favorites on
+	 * behalf of any user against any record (privilege-escalation primitive — Issue #2).
+	 *
+	 * Only the user's actual choice (`value`) is mass-assignable; the rest must be set
+	 * server-side via `FavoritesTable::add($model, $foreignKey, $userId, $value)`.
 	 *
 	 * @var array<string, bool>
 	 */
 	protected array $_accessible = [
-		'*' => true,
+		'value' => true,
 		'id' => false,
+		'user_id' => false,
+		'model' => false,
+		'foreign_key' => false,
+		'created' => false,
 	];
 
 }

--- a/tests/TestCase/Controller/Admin/FavoritesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FavoritesControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Favorites\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -19,6 +20,30 @@ class FavoritesControllerTest extends TestCase {
 	protected array $fixtures = [
 		'plugin.Favorites.Favorites',
 	];
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Configure::write('Favorites.models', ['Threads' => 'Threads']);
+		// The plugin's beforeFilter requires `Favorites.adminAccess` to be a Closure
+		// returning true for permitted callers. Tests run as a permitted caller by
+		// default; individual tests can override the gate to assert the deny path.
+		Configure::write('Favorites.adminAccess', function ($request): bool {
+			return true;
+		});
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Configure::delete('Favorites.adminAccess');
+
+		parent::tearDown();
+	}
 
 	/**
 	 * @uses \Favorites\Controller\Admin\FavoritesController::index()

--- a/tests/TestCase/View/Helper/StarsHelperTest.php
+++ b/tests/TestCase/View/Helper/StarsHelperTest.php
@@ -78,12 +78,9 @@ class StarsHelperTest extends TestCase {
 	 */
 	public function testLinkIconStarred(): void {
 		Configure::write('Auth.User.id', 1);
-		$favorite = $this->getTableLocator()->get('Favorites.Favorites')->newEntity([
-			'model' => 'Posts',
-			'foreign_key' => 1,
-			'user_id' => 1,
-		]);
-		$this->getTableLocator()->get('Favorites.Favorites')->saveOrFail($favorite);
+		// Foreign keys on `Favorite` are not mass-assignable (Issue #2); use the
+		// FavoritesTable::add() server-side API instead of newEntity().
+		$this->getTableLocator()->get('Favorites.Favorites')->add('Posts', 1, 1);
 
 		$result = $this->Stars->linkIcon('Posts', 1);
 		$this->assertStringStartsWith('<a href="#" onclick="document.post_', $result);


### PR DESCRIPTION
## Summary

Hardens the Favorites plugin: default-deny gate on the admin namespace, mass-assignment lockdown on the entity, and a robustness/type-safety pass across the three favorite-style components and their controllers.

## Default-deny admin gate

Modeled on the `Queue.adminAccess` pattern. Host apps must set `Favorites.adminAccess` to a Closure that returns `true` for permitted callers; otherwise the controller throws `ForbiddenException`. Coexists with `cakephp/authorization` by skipping the policy check (the gate IS the authorization decision for these controllers).

```php
Configure::write('Favorites.adminAccess', function (\Cake\Http\ServerRequest \$request): bool {
    \$identity = \$request->getAttribute('identity');
    return \$identity !== null && in_array('admin', (array)\$identity->roles, true);
});
```

## Favorite entity mass-assignment lockdown

`_accessible` now whitelists only `value`. Foreign keys (`user_id`, `model`, `foreign_key`) and `created` are explicitly `false`. Previously the entity used `'*' => true`, which would let any host app exposing a CRUD endpoint, admin form, or fixture factory using `patchEntity()` forge favorites on behalf of any user against any record. The plugin's own controllers were already safe (they bypass `patchEntity()` and pass uid explicitly via `FavoritesTable::add()`), but the entity was a clear privilege-escalation foot-gun.

## Component robustness

- `LikeableComponent`, `StarableComponent`, `FavoriteableComponent::process()` now reject missing `id` / `alias` / `action` keys with `BadRequestException` instead of raising "Undefined array key" warnings.
- `FavoriteableComponent::callbackToggle` no longer reads the deprecated CakePHP 2.x `passedArgs` property; uses `getRequest()->getQuery()` and strict comparison so non-bool truthy values (`'admin'`, `'true'`, ...) from custom auth backends cannot satisfy `is_admin == true`.

## Bug fix

`LikesController::dislike` had an inverted error condition: the success path flashed as a failure and the actual failure path was silent. Aligned with `like()`.

## Type safety

All public actions in `FavoritesController`, `LikesController`, `StarsController`, and `Admin\FavoritesController` now declare native `Cake\Http\Response|null` return types and typed parameters.

## Admin reset hardening

`Admin\FavoritesController::index()` now whitelists the `model` query parameter against `Favorites.models` and uses placeholder-style i18n (`__('... {0} ... {1}.', \$model, \$count)`). The previous code concatenated the value into the translation key, polluting the i18n cache and silently issuing `DELETE WHERE model=''` for unmapped values.

## Tests

- 53/53 pass (1 pre-existing incomplete).
- `Admin\FavoritesControllerTest` configures `Favorites.adminAccess` in `setUp`.
- `StarsHelperTest::testLinkIconStarred` stops using `newEntity()` (which would now filter out the foreign keys) and uses `FavoritesTable::add()` instead.