### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/favorites.pot
+++ b/resources/locales/favorites.pot
@@ -1,0 +1,121 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 03:21+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Favorites admin backend is not configured. Set Favorites.adminAccess to a Closure that returns true for permitted callers."
+msgstr ""
+
+msgid "Favorites admin access denied."
+msgstr ""
+
+msgid "The favorites have been reset for `{0}`, deleted: {1}."
+msgstr ""
+
+msgid "The favorite has been deleted."
+msgstr ""
+
+msgid "The favorite could not be deleted. Please, try again."
+msgstr ""
+
+msgid "An error occurred."
+msgstr ""
+
+msgid "The Favorite has been saved."
+msgstr ""
+
+msgid "The Favorite could not be saved. Please, try again."
+msgstr ""
+
+msgid "Nonrestricted operation"
+msgstr ""
+
+msgid "The Favorite status has been updated."
+msgstr ""
+
+msgid "Error appear during favorite status update. Try later."
+msgstr ""
+
+msgid "The Favorite has been deleted."
+msgstr ""
+
+msgid "Error appear during favorite deleting. Try later."
+msgstr ""
+
+msgid "Could not save favorite, please try again."
+msgstr ""
+
+msgid "You are not authorized to remove this favorite."
+msgstr ""
+
+msgid "Could not save like, please try again."
+msgstr ""
+
+msgid "Could not save dislike, please try again."
+msgstr ""
+
+msgid "Remove reaction"
+msgstr ""
+
+msgid "Add reaction"
+msgstr ""
+
+msgid "Reset rating"
+msgstr ""
+
+msgid "Rate me"
+msgstr ""
+
+msgid "Starred by you. Click to unstar."
+msgstr ""
+
+msgid "Click to star."
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+msgid "Value"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "first"
+msgstr ""
+
+msgid "last"
+msgstr ""
+
+msgid "previous"
+msgstr ""
+
+msgid "next"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+

--- a/src/Controller/Admin/FavoritesController.php
+++ b/src/Controller/Admin/FavoritesController.php
@@ -81,13 +81,13 @@ class FavoritesController extends AppController {
 			$model = $this->request->getQuery('model');
 			// Whitelist against `Favorites.models` — without this, `reset()` happily issues
 			// `DELETE FROM favorites_favorites WHERE model = ''` for unmapped values, and the
-			// query parameter would pollute the i18n cache when concatenated into __() (Issue #3).
+			// query parameter would pollute the i18n cache when concatenated into the translator call.
 			$allowed = array_keys((array)Configure::read('Favorites.models'));
 			if (!is_string($model) || !in_array($model, $allowed, true)) {
 				throw new BadRequestException('Invalid model');
 			}
 			$count = $this->Favorites->reset($model);
-			$this->Flash->success(__('The favorites have been reset for `{0}`, deleted: {1}.', $model, $count));
+			$this->Flash->success(__d('favorites', 'The favorites have been reset for `{0}`, deleted: {1}.', $model, $count));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -122,9 +122,9 @@ class FavoritesController extends AppController {
 		$this->request->allowMethod(['post', 'delete']);
 		$favorite = $this->Favorites->get($id);
 		if ($this->Favorites->delete($favorite)) {
-			$this->Flash->success(__('The favorite has been deleted.'));
+			$this->Flash->success(__d('favorites', 'The favorite has been deleted.'));
 		} else {
-			$this->Flash->error(__('The favorite could not be deleted. Please, try again.'));
+			$this->Flash->error(__d('favorites', 'The favorite could not be deleted. Please, try again.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/templates/Admin/Favorites/index.php
+++ b/templates/Admin/Favorites/index.php
@@ -7,14 +7,14 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
-        <li class="nav-item heading"><?= __('Actions') ?></li>
+        <li class="nav-item heading"><?= __d('favorites', 'Actions') ?></li>
         <li class="nav-item">
         </li>
     </ul>
 </nav>
 <div class="favorites index content large-9 medium-8 columns col-sm-8 col-12">
 
-    <h2><?= __('Favorites') ?></h2>
+    <h2><?= __d('favorites', 'Favorites') ?></h2>
 
     <ul>
 		<?php foreach ($models as $model => $count): ?>
@@ -30,7 +30,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 		<?php endforeach; ?>
 	</ul>
 
-	<p><?= $this->Html->link(__('Details'), ['action' => 'listing'], ['class' => '']) ?></p>
+	<p><?= $this->Html->link(__d('favorites', 'Details'), ['action' => 'listing'], ['class' => '']) ?></p>
 
 </div>
 <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>

--- a/templates/Admin/Favorites/listing.php
+++ b/templates/Admin/Favorites/listing.php
@@ -7,15 +7,15 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
-        <li class="nav-item heading"><?= __('Actions') ?></li>
+        <li class="nav-item heading"><?= __d('favorites', 'Actions') ?></li>
         <li class="nav-item">
-			<?= $this->Html->link(__('Back'), ['action' => 'index'], ['class' => 'nav-link']) ?>
+			<?= $this->Html->link(__d('favorites', 'Back'), ['action' => 'index'], ['class' => 'nav-link']) ?>
         </li>
     </ul>
 </nav>
 <div class="favorites index content large-9 medium-8 columns col-sm-8 col-12">
 
-    <h2><?= __('Favorites') ?></h2>
+    <h2><?= __d('favorites', 'Favorites') ?></h2>
 
     <div class="">
         <table class="table table-sm table-striped">
@@ -24,9 +24,9 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     <th><?= $this->Paginator->sort('model') ?></th>
                     <th><?= $this->Paginator->sort('foreign_key') ?></th>
                     <th><?= $this->Paginator->sort('user_id') ?></th>
-					<th><?= __('Value') ?></th>
+					<th><?= __d('favorites', 'Value') ?></th>
                     <th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
-                    <th class="actions"><?= __('Actions') ?></th>
+                    <th class="actions"><?= __d('favorites', 'Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -41,7 +41,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     <td><?= $this->Time->nice($comment->created) ?></td>
                     <td class="actions">
                         <?php
-						$label = __('Delete');
+						$label = __d('favorites', 'Delete');
 						if ($this->helpers()->has('Icon')) {
 							$label = $this->Icon->render('delete');
 						}
@@ -50,7 +50,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 							'class' => 'btn btn-link p-0 align-baseline',
 							'form' => [
 								'class' => 'd-inline',
-								'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+								'data-confirm-message' => __d('favorites', 'Are you sure you want to delete # {0}?', $comment->id),
 							],
 						]);
 						?>

--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -14,19 +14,19 @@ if (!isset($separator)) {
 }
 
 if (empty($first)) {
-	$first = __d('tools', 'first');
+	$first = __d('favorites', 'first');
 }
 if (empty($last)) {
-	$last = __d('tools', 'last');
+	$last = __d('favorites', 'last');
 }
 if (empty($prev)) {
-	$prev = __d('tools', 'previous');
+	$prev = __d('favorites', 'previous');
 }
 if (empty($next)) {
-	$next = __d('tools', 'next');
+	$next = __d('favorites', 'next');
 }
 if (!isset($format)) {
-	$format = __d('tools', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total');
+	$format = __d('favorites', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total');
 }
 if (!empty($reverse)) {
 	$tmp = $first;


### PR DESCRIPTION
## Summary

- Convert 14 `__()` calls in `src/` and `templates/` to `__d('favorites', ...)` so plugin strings live in their own domain.
- Re-route the 5 pre-existing `__d('tools', ...)` calls in `templates/element/pagination.php` to `__d('favorites', ...)`. These were leftovers from when the element was copied from `cakephp-tools` — the plugin should own its own strings.
- The 25 pre-existing `__d('favorites', ...)` calls already pointed at the right domain.
- Add `resources/locales/favorites.pot` (35 unique msgids) generated via `bin/cake i18n extract`.

## Why

Plugin strings were either landing in the host app's `default` domain (14 calls) or in a sibling plugin's `tools` domain (5 calls). Either way, anyone wanting to ship a German/Japanese/etc. language pack with `cakephp-favorites` couldn't, because the strings weren't owned by this plugin.

## Verification (local)

- phpunit: 53 / 53 (1 pre-existing incomplete, unrelated)
- phpstan: no errors
- phpcs: clean