### PR TITLE
Fix three top-3 favorites bugs: unique index, failure check, Starred association

### DIFF
--- a/config/Migrations/20260513000000_TightenFavoriteUniqueIndex.php
+++ b/config/Migrations/20260513000000_TightenFavoriteUniqueIndex.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+/**
+ * Tighten the per-user-per-record uniqueness constraint.
+ *
+ * The original migration shipped a UNIQUE index on
+ * `(model, foreign_key, user_id, value)`. Including `value` is wrong:
+ * a row with `value=1` (a like) and a row with `value=-1` (a dislike)
+ * for the same `(model, foreign_key, user_id)` both pass the
+ * constraint, so a single user could simultaneously be on record as
+ * having liked AND disliked the same article. The application-level
+ * `findOrCreate` in `FavoritesTable::add()` masks this in the happy
+ * path (it queries on `(model, foreign_key, user_id)` and updates
+ * `value` in place), but a direct `LikeableBehavior::addLike()`
+ * followed by `addDislike()` produces two rows because the constraint
+ * doesn't catch it.
+ *
+ * This drops the four-column unique index and replaces it with a
+ * three-column one keyed on `(model, foreign_key, user_id)`, matching
+ * the application-level intent. The released migration is left
+ * untouched.
+ */
+class TightenFavoriteUniqueIndex extends BaseMigration {
+
+	public function up(): void {
+		$this->table('favorites_favorites')
+			->removeIndexByName('favorite_unique')
+			->addIndex(
+				['model', 'foreign_key', 'user_id'],
+				['name' => 'favorite_unique', 'unique' => true],
+			)
+			->update();
+	}
+
+	public function down(): void {
+		$this->table('favorites_favorites')
+			->removeIndexByName('favorite_unique')
+			->addIndex(
+				['model', 'foreign_key', 'user_id', 'value'],
+				['name' => 'favorite_unique', 'unique' => true],
+			)
+			->update();
+	}
+
+}

--- a/src/Controller/FavoritesController.php
+++ b/src/Controller/FavoritesController.php
@@ -65,7 +65,7 @@ class FavoritesController extends AppController {
 		}
 
 		$result = $this->Favorites->add($model, $entity->get('id'), $uid, $value);
-		if ($result->isNew()) {
+		if ($result->hasErrors()) {
 			$this->Flash->error(__d('favorites', 'Could not save favorite, please try again.'));
 		}
 

--- a/src/Controller/LikesController.php
+++ b/src/Controller/LikesController.php
@@ -56,7 +56,7 @@ class LikesController extends AppController {
 		}
 
 		$result = $this->Favorites->add($model, $entity->get('id'), $uid, 1);
-		if ($result->isNew()) {
+		if ($result->hasErrors()) {
 			$this->Flash->error(__d('favorites', 'Could not save like, please try again.'));
 		}
 
@@ -85,9 +85,7 @@ class LikesController extends AppController {
 		}
 
 		$result = $this->Favorites->add($model, $entity->get('id'), $uid, -1);
-		// `isNew()` is true for unsaved entities — that IS the failure case (Issue #1).
-		// Flash an error only when persistence actually didn't happen.
-		if ($result->isNew()) {
+		if ($result->hasErrors()) {
 			$this->Flash->error(__d('favorites', 'Could not save dislike, please try again.'));
 		}
 

--- a/src/Controller/StarsController.php
+++ b/src/Controller/StarsController.php
@@ -56,8 +56,8 @@ class StarsController extends AppController {
 		}
 
 		$result = $this->Favorites->add($model, $entity->get('id'), $uid);
-		if ($result->isNew()) {
-			$this->Flash->error(__d('favorites', 'Could not save like, please try again.'));
+		if ($result->hasErrors()) {
+			$this->Flash->error(__d('favorites', 'Could not save star, please try again.'));
 		}
 
 		return $this->redirect($this->referer(['action' => 'index']));

--- a/src/Model/Behavior/StarableBehavior.php
+++ b/src/Model/Behavior/StarableBehavior.php
@@ -71,14 +71,29 @@ class StarableBehavior extends Behavior {
 			'dependent' => true,
 		]);
 
+		// `Starred` is attached unconditionally so admin/list templates can
+		// always `contain('Starred')` and filter the user_id at query time:
+		//
+		//   $articles->find()->contain([
+		//       'Starred' => fn ($q) => $q->where(['Starred.user_id' => $userId]),
+		//   ]);
+		//
+		// When `userId` is supplied at addBehavior() time, the condition is
+		// baked into the association so apps that already rely on that
+		// behavior keep working without code changes. The previous
+		// implementation gated the whole `hasOne` on `userId`, so any
+		// controller that didn't know a user up-front lost the Starred
+		// association entirely.
+		$starredConditions = ['Starred.model' => $this->getConfig('model')];
 		if (!empty($config['userId'])) {
-			$this->_table->hasOne('Starred', [
-				'className' => $this->getConfig('favoriteClass'),
-				'foreignKey' => 'foreign_key',
-				'conditions' => ['Starred.model' => $this->getConfig('model'), 'Starred.user_id' => $config['userId']],
-				'dependent' => true,
-			]);
+			$starredConditions['Starred.user_id'] = $config['userId'];
 		}
+		$this->_table->hasOne('Starred', [
+			'className' => $this->getConfig('favoriteClass'),
+			'foreignKey' => 'foreign_key',
+			'conditions' => $starredConditions,
+			'dependent' => true,
+		]);
 
 		if ($this->getConfig('counterCache')) {
 			$this->favoritesTable()->addBehavior('CounterCache', [

--- a/tests/Fixture/FavoritesFixture.php
+++ b/tests/Fixture/FavoritesFixture.php
@@ -33,6 +33,10 @@ class FavoritesFixture extends TestFixture {
 		],
 		'_constraints' => [
 			'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+			// Matches the tightened constraint from
+			// 20260513000000_TightenFavoriteUniqueIndex: a single user
+			// gets exactly one favorite row per (model, foreign_key).
+			'favorite_unique' => ['type' => 'unique', 'columns' => ['model', 'foreign_key', 'user_id'], 'length' => []],
 		],
 	];
 

--- a/tests/TestCase/Controller/LikesControllerTest.php
+++ b/tests/TestCase/Controller/LikesControllerTest.php
@@ -36,6 +36,7 @@ class LikesControllerTest extends TestCase {
 	 */
 	public function testLike(): void {
 		$this->disableErrorHandlerMiddleware();
+		$this->enableRetainFlashMessages();
 
 		Configure::write('Favorites.models.Posts', 'Posts');
 
@@ -50,6 +51,27 @@ class LikesControllerTest extends TestCase {
 		$this->post(['plugin' => 'Favorites', 'controller' => 'Likes', 'action' => 'like', 'Posts', 1]);
 
 		$this->assertRedirect(['action' => 'index']);
+
+		// Regression: prior code used `$result->isNew()` to detect failure,
+		// but `findOrCreate` + `saveOrFail` always returns a non-new entity
+		// — so on the success path the error message NEVER fires (correct
+		// for the success case but means the error branch was unreachable
+		// for the actual failure case). The hasErrors() switch makes the
+		// guard meaningful again. Either way, a successful POST must
+		// land a row and not leave a stale error flash sitting in session.
+		$row = $this->fetchTable('Favorites.Favorites')->find()
+			->where(['model' => 'Posts', 'foreign_key' => 1, 'user_id' => 1, 'value' => 1])
+			->first();
+		$this->assertNotNull($row, 'A like row must have landed in the DB.');
+
+		$flash = $this->_requestSession->read('Flash.flash') ?? [];
+		foreach ($flash as $message) {
+			$this->assertNotSame(
+				__d('favorites', 'Could not save like, please try again.'),
+				$message['message'] ?? null,
+				'A successful like must not flash a "could not save" error.',
+			);
+		}
 
 		Configure::delete('Favorites.models');
 	}

--- a/tests/TestCase/Model/Behavior/StarableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StarableBehaviorTest.php
@@ -83,4 +83,33 @@ class StarableBehaviorTest extends TestCase {
 		$this->assertCount(0, $favorites);
 	}
 
+	/**
+	 * Regression: the `Starred` association must be attached even when the
+	 * behavior is loaded without a `userId` config (the normal case from
+	 * `Table::initialize()`). Without it, controllers and templates that
+	 * want `->contain('Starred')` would error out with "association not
+	 * found".
+	 *
+	 * @return void
+	 */
+	public function testStarredAssociationAvailableWithoutUserIdConfig(): void {
+		$this->assertTrue(
+			$this->table->hasAssociation('Starred'),
+			'Starred hasOne must exist even when addBehavior() was called with no userId.',
+		);
+
+		// (No `set` call needed; the fixture provides a row.)
+		// Association is usable: containment query doesn't blow up and
+		// returns rows scoped to the requested user via overlaid conditions.
+		// The fixture already provides a Favorite for user 1 on Post 1, so
+		// no extra setup is needed.
+		$row = $this->table->find()
+			->contain(['Starred' => fn ($q) => $q->where(['Starred.user_id' => 1])])
+			->where(['Posts.id' => 1])
+			->first();
+
+		$this->assertNotNull($row);
+		$this->assertNotNull($row->starred, 'Starred must hydrate from the fixture row.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/FavoritesTableTest.php
+++ b/tests/TestCase/Model/Table/FavoritesTableTest.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Favorites\Test\TestCase\Model\Table;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\TestSuite\TestCase;
 use Favorites\Model\Table\FavoritesTable;
+use PDOException;
 
 /**
  * Favorites\Model\Table\FavoritesTable Test Case
@@ -85,6 +87,43 @@ class FavoritesTableTest extends TestCase {
 
 		$favorites = $this->Favorites->find()->all()->toArray();
 		$this->assertCount(1, $favorites);
+	}
+
+	/**
+	 * Regression for the tightened unique index. The application path
+	 * (`FavoritesTable::add()`) already uses `findOrCreate` so it
+	 * doesn't accidentally duplicate, but the DB-level constraint
+	 * previously allowed duplicate `(model, foreign_key, user_id)`
+	 * rows as long as `value` differed. Any direct INSERT — a custom
+	 * import, a race between two `findOrCreate` calls, or a future
+	 * `newEntity()` + `save()` path — would land both rows.
+	 *
+	 * @return void
+	 */
+	public function testUniqueIndexPreventsDuplicatePerUserPerRecord(): void {
+		// Wipe the fixture row so the asserts measure the constraint, not it.
+		$this->Favorites->deleteAll(['1=1']);
+
+		// Build directly via set(guard=false) — the entity's `_accessible`
+		// allowlist blocks mass-assign of identity columns by design
+		// (those are set server-side via FavoritesTable::add).
+		$first = $this->Favorites->newEmptyEntity();
+		$first->patch(['model' => 'Posts', 'foreign_key' => 1, 'user_id' => 1, 'value' => 1], ['guard' => false]);
+		$this->Favorites->saveOrFail($first);
+
+		$second = $this->Favorites->newEmptyEntity();
+		$second->patch(['model' => 'Posts', 'foreign_key' => 1, 'user_id' => 1, 'value' => -1], ['guard' => false]);
+
+		try {
+			$this->Favorites->save($second, ['atomic' => false]);
+			$this->fail('Expected duplicate-key violation on second insert.');
+		} catch (DatabaseException) {
+			// Expected: tightened unique index trips on the second row.
+		} catch (PDOException) {
+			// Some drivers wrap as PDOException — also acceptable.
+		}
+
+		$this->assertSame(1, $this->Favorites->find()->count(), 'Only the first row should have landed.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Three independent correctness fixes from the merged review's top-3 list. Shipped together because they share a single plugin and a tight regression-test footprint.

### 1. Tighten the per-user-per-record unique constraint

The original migration shipped a UNIQUE index on `(model, foreign_key, user_id, value)`. Including `value` is wrong: a row with `value=1` (a like) and one with `value=-1` (a dislike) for the same `(model, foreign_key, user_id)` both pass the constraint. The application's `FavoritesTable::add()` uses `findOrCreate` on the tuple without `value`, so the happy path doesn't trip — but any direct INSERT, a race between two `findOrCreate` calls, or a future `newEntity()`+`save()` path lands both rows.

New migration `20260513000000_TightenFavoriteUniqueIndex` drops the four-column index and replaces it with a three-column one keyed on `(model, foreign_key, user_id)`. The released migration is left untouched. Test fixture updated to match.

### 2. Fix the inverted "could not save" failure check

`LikesController`, `FavoritesController`, and `StarsController` all guarded their flash with `if ($result->isNew())`. `FavoritesTable::add()` routes through `findOrCreate`+`saveOrFail`; the entity is never new after a successful return. The check matched the validation-error early-return only by coincidence — the rest of the failure surface was unreachable. Switched to `if ($result->hasErrors())` which catches the real validation-error case explicitly.

`StarsController` also had a copy-pasted "Could not save like" message even though it dispatches a star; corrected to "Could not save star".

### 3. Make `Starred` association available without addBehavior-time userId

`StarableBehavior::initialize()` gated the entire `Starred` hasOne on the presence of `$config['userId']`. Apps that `addBehavior()` in `Table::initialize()` (the normal place) almost never know a user then, so the association was unavailable to admin/list templates that want `->contain('Starred')`.

Drop the gate. Attach `Starred` unconditionally with the model condition only; if `userId` IS supplied at config-time, bake it in (backwards-compat). Apps that want per-request scoping pass the `user_id` via overlay conditions:

```php
$query->contain([
    'Starred' => fn ($q) => $q->where(['Starred.user_id' => $uid]),
]);
```

## Tests

- `testUniqueIndexPreventsDuplicatePerUserPerRecord` — direct save of a second row for the same `(model, foreign_key, user_id)` tuple is rejected by the DB constraint.
- `testLike` extended — a successful POST persists a row AND does not flash the error message via stale session.
- `testStarredAssociationAvailableWithoutUserIdConfig` — `Starred` is attached + queryable when `addBehavior()` was called without `userId`.

55 existing tests still pass; phpcs clean; phpstan clean.
