### PR TITLE
Make favorites foreign_key type configurable via Polymorphic.type

### DIFF
--- a/config/Migrations/20240305193906_PluginFavorites.php
+++ b/config/Migrations/20240305193906_PluginFavorites.php
@@ -15,18 +15,22 @@ class PluginFavorites extends BaseMigration {
 	 * @return void
 	 */
 	public function change(): void {
-		// foreign_key (polymorphic host record) and user_id reference primary keys,
-		// so they follow the application's primary-key signedness. The flag is false
-		// (signed) when unset, so an unset flag yields signed columns matching the
-		// default-signed ids they reference. Unsigned only on MySQL.
+		// foreign_key (polymorphic host record) follows the Polymorphic.type config so
+		// apps using UUID primary keys can store matching foreign keys. user_id is a
+		// concrete FK to app users and always follows the primary-key signedness.
+		$type = (string)Configure::read('Polymorphic.type', 'integer');
 		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
 
+		$polymorphicOptions = [
+			'default' => null,
+			'null' => false,
+		];
+		if (in_array($type, ['integer', 'biginteger'], true)) {
+			$polymorphicOptions['signed'] = $signed;
+		}
+
 		$this->table('favorites_favorites')
-			->addColumn('foreign_key', 'integer', [
-				'default' => null,
-				'null' => false,
-				'signed' => $signed,
-			])
+			->addColumn('foreign_key', $type, $polymorphicOptions)
 			->addColumn('model', 'string', [
 				'default' => null,
 				'limit' => 80,

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,23 @@ This can be needed, if you want to display a validation result on the form itsel
 - [Like](Like.md)
 - [Favorite](Favorite.md)
 
+## Database Configuration
+
+### Polymorphic foreign key type
+
+The `favorites_favorites.foreign_key` column type is configurable via the global
+`Polymorphic.type` key. This allows apps that use UUID or binary-UUID primary keys
+to store matching foreign keys in the favorites table.
+
+```php
+// config/app.php or config/app_local.php
+Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
+```
+
+For `integer` and `biginteger` types, column signedness follows `Migrations.unsigned_primary_keys`
+(unsigned when `true`, signed otherwise). For `uuid` and `binaryuuid` types, no signedness option
+is applied. The concrete `user_id` column is always `integer` and unaffected by this setting.
+
 ## Admin Backend
 Go to `/admin/favorites`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,10 +63,18 @@ The `favorites_favorites.foreign_key` column type is configurable via the global
 `Polymorphic.type` key. This allows apps that use UUID or binary-UUID primary keys
 to store matching foreign keys in the favorites table.
 
+Set the type in your app config so it is available during bootstrap and migrations:
+
 ```php
-// config/app.php or config/app_local.php
-Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
+// config/app.php (merged into Configure at bootstrap, including the migrations CLI)
+'Polymorphic' => [
+    'type' => 'uuid', // integer (default) | biginteger | uuid | binaryuuid
+],
 ```
+
+This setting applies to fresh installs — the migration uses it when creating the column.
+Existing installs keep their current column type; to change it you need an app-side migration
+that alters the `foreign_key` column to the new type.
 
 For `integer` and `biginteger` types, column signedness follows `Migrations.unsigned_primary_keys`
 (unsigned when `true`, signed otherwise). For `uuid` and `binaryuuid` types, no signedness option


### PR DESCRIPTION
## Problem

`favorites_favorites.foreign_key` is a polymorphic reference — it points at an arbitrary host record's primary key, so its column type should match whatever the host uses. It was hardcoded as `integer`, which cannot match apps whose host records use `biginteger` or UUID primary keys.

## Fix

The polymorphic column now follows a single global config key, `Polymorphic.type`, shared across the polymorphic-FK plugins:

```php
// config/app.php or config/app_local.php
Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
```

- Default `integer` (the CakePHP default), so behavior is unchanged for the common case.
- For the integer variants, signedness follows `Migrations.unsigned_primary_keys`; `uuid` / `binaryuuid` set no signedness.
- The concrete FK column `user_id` stays `integer` and is unaffected.

Editing the create migration sets the default for fresh installs; existing installs are unaffected (the create migration does not re-run). Type/signedness only take effect on MySQL for the integer variants.
