### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Controller/Admin/FavoritesController.php
+++ b/src/Controller/Admin/FavoritesController.php
@@ -60,8 +60,6 @@ class FavoritesController extends AppController {
 
 		try {
 			$allowed = $gate($this->request) === true;
-		} catch (ForbiddenException $e) {
-			throw $e;
 		} catch (Throwable $e) {
 			Log::warning(sprintf('Favorites.adminAccess threw %s: %s', $e::class, $e->getMessage()));
 
@@ -99,7 +97,7 @@ class FavoritesController extends AppController {
 			->find('list', ...['keyField' => 'model', 'valueField' => 'count'])
 			->toArray();
 
-		$this->set(compact('models'));
+		$this->set(['models' => $models]);
 	}
 
 	/**
@@ -110,7 +108,7 @@ class FavoritesController extends AppController {
 			->contain(['Users']);
 		$favorites = $this->paginate($query);
 
-		$this->set(compact('favorites'));
+		$this->set(['favorites' => $favorites]);
 	}
 
 	/**

--- a/src/Controller/Admin/FavoritesController.php
+++ b/src/Controller/Admin/FavoritesController.php
@@ -97,7 +97,7 @@ class FavoritesController extends AppController {
 			->find('list', ...['keyField' => 'model', 'valueField' => 'count'])
 			->toArray();
 
-		$this->set(['models' => $models]);
+		$this->set(compact('models'));
 	}
 
 	/**
@@ -108,7 +108,7 @@ class FavoritesController extends AppController {
 			->contain(['Users']);
 		$favorites = $this->paginate($query);
 
-		$this->set(['favorites' => $favorites]);
+		$this->set(compact('favorites'));
 	}
 
 	/**

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -237,7 +237,7 @@ class FavoriteableComponent extends Component {
 		$model = $this->Controller->fetchTable();
 		$this->modelAlias = $model->getAlias();
 
-		$parts = explode('\\', (string) $model->getEntityClass());
+		$parts = explode('\\', (string)$model->getEntityClass());
 		$entityName = Inflector::classify(Inflector::underscore(array_pop($parts)));
 		$this->viewVariable = Inflector::variable($entityName);
 		if (!$this->Controller->{$this->modelAlias}->behaviors()->has('Favoriteable')) {
@@ -439,19 +439,19 @@ class FavoriteableComponent extends Component {
 	 */
 	public function callbackAdd($modelId, $displayType) {
 		if (!empty($this->Controller->data)) {
-            $modelName = $this->Controller->{$this->modelAlias}->alias;
-            if (!empty($this->Controller->{$this->modelAlias}->fullName)) {
+			$modelName = $this->Controller->{$this->modelAlias}->alias;
+			if (!empty($this->Controller->{$this->modelAlias}->fullName)) {
 				$modelName = $this->Controller->{$this->modelAlias}->fullName;
 			}
-            $options = [
+			$options = [
 				'userId' => $this->userId(),
 				'modelId' => $modelId,
 				'modelName' => $modelName,
 			];
-            /** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
-            $behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
-            $result = $behavior->addFavorite($options);
-            if ($result !== null) {
+			/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
+			$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
+			$result = $behavior->addFavorite($options);
+			if ($result !== null) {
 				if ($result) {
 					try {
 						$options['favoriteId'] = $result;
@@ -472,14 +472,14 @@ class FavoriteableComponent extends Component {
 					$this->flash(__d('favorites', 'The Favorite could not be saved. Please, try again.'));
 				}
 			}
-        } elseif (!empty($this->Controller->passedArgs['quote'])) {
-            if (!empty($this->Controller->passedArgs['favorite'])) {
+		} elseif (!empty($this->Controller->passedArgs['quote'])) {
+			if (!empty($this->Controller->passedArgs['favorite'])) {
 					$message = $this->_call('getFormatedFavorite', [$this->Controller->passedArgs['favorite']]);
-					if ($message) {
-						//$this->Controller->request->data['Favorite']['body'] = $message;
-					}
+				if ($message) {
+					//$this->Controller->request->data['Favorite']['body'] = $message;
 				}
-        }
+			}
+		}
 	}
 
 	/**

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -237,7 +237,7 @@ class FavoriteableComponent extends Component {
 		$model = $this->Controller->fetchTable();
 		$this->modelAlias = $model->getAlias();
 
-		$parts = explode('\\', $model->getEntityClass());
+		$parts = explode('\\', (string) $model->getEntityClass());
 		$entityName = Inflector::classify(Inflector::underscore(array_pop($parts)));
 		$this->viewVariable = Inflector::variable($entityName);
 		if (!$this->Controller->{$this->modelAlias}->behaviors()->has('Favoriteable')) {
@@ -398,7 +398,7 @@ class FavoriteableComponent extends Component {
 		}
 
 		$id = $entity->get('id');
-		$options = compact('displayType', 'id');
+		$options = ['displayType' => $displayType, 'id' => $id];
 		if ($processActions) {
 			//TODO
 			//$this->_processActions($options);
@@ -406,7 +406,7 @@ class FavoriteableComponent extends Component {
 
 		try {
 			$data = $this->_call('fetchData' . Inflector::camelize($displayType), [$options]);
-		} catch (BadMethodCallException $exception) {
+		} catch (BadMethodCallException) {
 			$data = $this->_call('fetchData', [$options]);
 		}
 
@@ -439,25 +439,24 @@ class FavoriteableComponent extends Component {
 	 */
 	public function callbackAdd($modelId, $displayType) {
 		if (!empty($this->Controller->data)) {
-			$modelName = $this->Controller->{$this->modelAlias}->alias;
-			if (!empty($this->Controller->{$this->modelAlias}->fullName)) {
+            $modelName = $this->Controller->{$this->modelAlias}->alias;
+            if (!empty($this->Controller->{$this->modelAlias}->fullName)) {
 				$modelName = $this->Controller->{$this->modelAlias}->fullName;
 			}
-			$options = [
+            $options = [
 				'userId' => $this->userId(),
 				'modelId' => $modelId,
 				'modelName' => $modelName,
 			];
-			/** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
-			$behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
-			$result = $behavior->addFavorite($options);
-
-			if ($result !== null) {
+            /** @var \Favorites\Model\Behavior\FavoriteableBehavior $behavior */
+            $behavior = $this->Controller->{$this->modelAlias}->getBehavior('Favoriteable');
+            $result = $behavior->addFavorite($options);
+            if ($result !== null) {
 				if ($result) {
 					try {
 						$options['favoriteId'] = $result;
 						$this->_call('afterAdd', [$options]);
-					} catch (BadMethodCallException $exception) {
+					} catch (BadMethodCallException) {
 					}
 					$this->flash(__d('favorites', 'The Favorite has been saved.'));
 					$this->prgRedirect(['#' => 'favorite' . $result]);
@@ -473,16 +472,14 @@ class FavoriteableComponent extends Component {
 					$this->flash(__d('favorites', 'The Favorite could not be saved. Please, try again.'));
 				}
 			}
-		} else {
-			if (!empty($this->Controller->passedArgs['quote'])) {
-				if (!empty($this->Controller->passedArgs['favorite'])) {
+        } elseif (!empty($this->Controller->passedArgs['quote'])) {
+            if (!empty($this->Controller->passedArgs['favorite'])) {
 					$message = $this->_call('getFormatedFavorite', [$this->Controller->passedArgs['favorite']]);
 					if ($message) {
 						//$this->Controller->request->data['Favorite']['body'] = $message;
 					}
 				}
-			}
-		}
+        }
 	}
 
 	/**
@@ -506,7 +503,7 @@ class FavoriteableComponent extends Component {
 		$isAdmin = false;
 		if ($user !== null) {
 			$flag = $user->user('is_admin');
-			$isAdmin = $flag === true || $flag === 1 || $flag === '1';
+			$isAdmin = in_array($flag, [true, 1, '1'], true);
 		}
 		if ($action !== 'toggle_approve' || !$isAdmin) {
 			throw new MethodNotAllowedException(__d('favorites', 'Nonrestricted operation'));

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -474,7 +474,7 @@ class FavoriteableComponent extends Component {
 			}
 		} elseif (!empty($this->Controller->passedArgs['quote'])) {
 			if (!empty($this->Controller->passedArgs['favorite'])) {
-					$message = $this->_call('getFormatedFavorite', [$this->Controller->passedArgs['favorite']]);
+				$message = $this->_call('getFormatedFavorite', [$this->Controller->passedArgs['favorite']]);
 				if ($message) {
 					//$this->Controller->request->data['Favorite']['body'] = $message;
 				}

--- a/src/Controller/Component/LikeableComponent.php
+++ b/src/Controller/Component/LikeableComponent.php
@@ -195,7 +195,7 @@ class LikeableComponent extends Component {
 		$this->modelName = $model->getRegistryAlias();
 		$this->modelAlias = $model->getAlias();
 
-		$parts = explode('\\', $model->getEntityClass());
+		$parts = explode('\\', (string) $model->getEntityClass());
 		$entityName = Inflector::classify(Inflector::underscore(array_pop($parts)));
 		$this->viewVariable = $this->getConfig('viewVariable') ?? Inflector::variable($entityName);
 		if (!$this->Controller->{$this->modelAlias}->behaviors()->has('Likeable')) {

--- a/src/Controller/Component/LikeableComponent.php
+++ b/src/Controller/Component/LikeableComponent.php
@@ -195,7 +195,7 @@ class LikeableComponent extends Component {
 		$this->modelName = $model->getRegistryAlias();
 		$this->modelAlias = $model->getAlias();
 
-		$parts = explode('\\', (string) $model->getEntityClass());
+		$parts = explode('\\', (string)$model->getEntityClass());
 		$entityName = Inflector::classify(Inflector::underscore(array_pop($parts)));
 		$this->viewVariable = $this->getConfig('viewVariable') ?? Inflector::variable($entityName);
 		if (!$this->Controller->{$this->modelAlias}->behaviors()->has('Likeable')) {

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -195,7 +195,7 @@ class StarableComponent extends Component {
 		$this->modelName = $model->getRegistryAlias();
 		$this->modelAlias = $model->getAlias();
 
-		$parts = explode('\\', $model->getEntityClass());
+		$parts = explode('\\', (string) $model->getEntityClass());
 		$entityName = Inflector::classify(Inflector::underscore(array_pop($parts)));
 		$this->viewVariable = $this->getConfig('viewVariable') ?? Inflector::variable($entityName);
 		if (!$this->Controller->{$this->modelAlias}->behaviors()->has('Starable')) {

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -195,7 +195,7 @@ class StarableComponent extends Component {
 		$this->modelName = $model->getRegistryAlias();
 		$this->modelAlias = $model->getAlias();
 
-		$parts = explode('\\', (string) $model->getEntityClass());
+		$parts = explode('\\', (string)$model->getEntityClass());
 		$entityName = Inflector::classify(Inflector::underscore(array_pop($parts)));
 		$this->viewVariable = $this->getConfig('viewVariable') ?? Inflector::variable($entityName);
 		if (!$this->Controller->{$this->modelAlias}->behaviors()->has('Starable')) {

--- a/src/View/Helper/FavoritesHelper.php
+++ b/src/View/Helper/FavoritesHelper.php
@@ -84,9 +84,8 @@ class FavoritesHelper extends Helper {
 			$data = $this->data('remove', $alias, $id);
 			$resetIcon = $this->icon($alias, $id, 0);
 			$options = ['escapeTitle' => false, 'block' => true, 'data' => $data];
-			$icon .= ' <details class="like-buttons"><summary>' . __d('favorites', 'Remove reaction') . '</summary>' . $this->Form->postLink($resetIcon, $url, $options) . '</details>';
 
-			return $icon;
+			return $icon . (' <details class="like-buttons"><summary>' . __d('favorites', 'Remove reaction') . '</summary>' . $this->Form->postLink($resetIcon, $url, $options) . '</details>');
 		}
 
 		$iconList = [];

--- a/src/View/Helper/LikesHelper.php
+++ b/src/View/Helper/LikesHelper.php
@@ -91,9 +91,8 @@ class LikesHelper extends Helper {
 			$data = $this->data('remove', $alias, $id);
 			$resetIcon = $this->icon($alias, $id, 0);
 			$options = ['escapeTitle' => false, 'block' => true, 'data' => $data];
-			$icon .= ' <details class="like-buttons"><summary>' . __d('favorites', 'Reset rating') . '</summary>' . $this->Form->postLink($resetIcon, $url, $options) . '</details>';
 
-			return $icon;
+			return $icon . (' <details class="like-buttons"><summary>' . __d('favorites', 'Reset rating') . '</summary>' . $this->Form->postLink($resetIcon, $url, $options) . '</details>');
 		}
 
 		$likeIcon = $this->icon($alias, $id, 1);

--- a/src/View/Helper/StarsHelper.php
+++ b/src/View/Helper/StarsHelper.php
@@ -97,9 +97,8 @@ class StarsHelper extends Helper {
 		}
 
 		$class = $value ? ' starred' : '';
-		$icon = sprintf($html, $class, ' ' . implode(' ', $attributes));
 
-		return $icon;
+		return sprintf($html, $class, ' ' . implode(' ', $attributes));
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('WINDOWS')) {
-	if (DS === '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS === '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -23,7 +23,7 @@ function addTablesFromSchemaFile(string $file, string $pluginName, array $tables
 		$fieldsObject = (new ReflectionClass($class))->getProperty('fields');
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		return $tables;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.