### PR TITLE
Drop optional TinyAuth dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
 	},
 	"require-dev": {
 		"cakephp/migrations": "^5.0.0",
-		"dereuromark/cakephp-tinyauth": "^4.2.0",
 		"fig-r/psr2r-sniffer": "dev-master",
 		"phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
 	},

--- a/src/Controller/AuthTrait.php
+++ b/src/Controller/AuthTrait.php
@@ -22,10 +22,16 @@ trait AuthTrait {
 		}
 
 		if ($this->components()->has('AuthUser')) {
-			return $this->AuthUser->user($userIdField);
+			$authUser = $this->components()->get('AuthUser');
+			if (method_exists($authUser, 'user')) {
+				return $authUser->user($userIdField);
+			}
 		}
 		if ($this->components()->has('Auth')) {
-			return $this->Auth->user($userIdField);
+			$auth = $this->components()->get('Auth');
+			if (method_exists($auth, 'user')) {
+				return $auth->user($userIdField);
+			}
 		}
 
 		return $this->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -357,9 +357,15 @@ class FavoriteableComponent extends Component {
 
 		$userId = $this->getConfig('userId') ?: null;
 		if (!$userId && $this->Controller->components()->has('AuthUser')) {
-			$userId = $this->Controller->AuthUser->user($userIdField);
+			$authUser = $this->Controller->components()->get('AuthUser');
+			if (method_exists($authUser, 'user')) {
+				$userId = $authUser->user($userIdField);
+			}
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
-			$userId = $this->Controller->Auth->user($userIdField);
+			$auth = $this->Controller->components()->get('Auth');
+			if (method_exists($auth, 'user')) {
+				$userId = $auth->user($userIdField);
+			}
 		} elseif (!$userId) {
 			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 		}
@@ -499,9 +505,9 @@ class FavoriteableComponent extends Component {
 		// non-bool truthy values from custom auth backends (`'admin'`, `'true'`, ...)
 		// can't slip past as `is_admin == true`.
 		$action = (string)$this->Controller->getRequest()->getQuery('favorite_action', '');
-		$user = $this->Controller->Auth ?? null;
+		$user = $this->Controller->components()->has('Auth') ? $this->Controller->components()->get('Auth') : null;
 		$isAdmin = false;
-		if ($user !== null) {
+		if ($user !== null && method_exists($user, 'user')) {
 			$flag = $user->user('is_admin');
 			$isAdmin = in_array($flag, [true, 1, '1'], true);
 		}
@@ -633,7 +639,10 @@ class FavoriteableComponent extends Component {
 				}
 			} else {
 				//$this->Controller->Session->write('Auth.redirect', $this->Controller->request['url']);
-				$this->Controller->redirect($this->Controller->Auth->getConfig('loginAction'));
+				$auth = $this->Controller->components()->has('Auth') ? $this->Controller->components()->get('Auth') : null;
+				if ($auth !== null && method_exists($auth, 'getConfig')) {
+					$this->Controller->redirect($auth->getConfig('loginAction'));
+				}
 			}
 		}
 	}

--- a/src/Controller/Component/FavoriteableComponent.php
+++ b/src/Controller/Component/FavoriteableComponent.php
@@ -640,7 +640,7 @@ class FavoriteableComponent extends Component {
 			} else {
 				//$this->Controller->Session->write('Auth.redirect', $this->Controller->request['url']);
 				$auth = $this->Controller->components()->has('Auth') ? $this->Controller->components()->get('Auth') : null;
-				if ($auth !== null && method_exists($auth, 'getConfig')) {
+				if ($auth !== null) {
 					$this->Controller->redirect($auth->getConfig('loginAction'));
 				}
 			}

--- a/src/Controller/Component/LikeableComponent.php
+++ b/src/Controller/Component/LikeableComponent.php
@@ -340,9 +340,15 @@ class LikeableComponent extends Component {
 
 		$userId = $this->getConfig('userId') ?: null;
 		if (!$userId && $this->Controller->components()->has('AuthUser')) {
-			$userId = $this->Controller->AuthUser->user($userIdField);
+			$authUser = $this->Controller->components()->get('AuthUser');
+			if (method_exists($authUser, 'user')) {
+				$userId = $authUser->user($userIdField);
+			}
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
-			$userId = $this->Controller->Auth->user($userIdField);
+			$auth = $this->Controller->components()->get('Auth');
+			if (method_exists($auth, 'user')) {
+				$userId = $auth->user($userIdField);
+			}
 		} elseif (!$userId) {
 			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 		}

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -348,9 +348,15 @@ class StarableComponent extends Component {
 
 		$userId = $this->getConfig('userId') ?: null;
 		if (!$userId && $this->Controller->components()->has('AuthUser')) {
-			$userId = $this->Controller->AuthUser->user($userIdField);
+			$authUser = $this->Controller->components()->get('AuthUser');
+			if (method_exists($authUser, 'user')) {
+				$userId = $authUser->user($userIdField);
+			}
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
-			$userId = $this->Controller->Auth->user($userIdField);
+			$auth = $this->Controller->components()->get('Auth');
+			if (method_exists($auth, 'user')) {
+				$userId = $auth->user($userIdField);
+			}
 		} elseif (!$userId) {
 			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 		}
@@ -453,7 +459,10 @@ class StarableComponent extends Component {
 				}
 			} else {
 				//$this->Controller->Session->write('Auth.redirect', $this->Controller->request['url']);
-				$this->Controller->redirect($this->Controller->Auth->getConfig('loginAction'));
+				$auth = $this->Controller->components()->has('Auth') ? $this->Controller->components()->get('Auth') : null;
+				if ($auth !== null && method_exists($auth, 'getConfig')) {
+					$this->Controller->redirect($auth->getConfig('loginAction'));
+				}
 			}
 		}
 	}

--- a/src/Controller/Component/StarableComponent.php
+++ b/src/Controller/Component/StarableComponent.php
@@ -460,7 +460,7 @@ class StarableComponent extends Component {
 			} else {
 				//$this->Controller->Session->write('Auth.redirect', $this->Controller->request['url']);
 				$auth = $this->Controller->components()->has('Auth') ? $this->Controller->components()->get('Auth') : null;
-				if ($auth !== null && method_exists($auth, 'getConfig')) {
+				if ($auth !== null) {
 					$this->Controller->redirect($auth->getConfig('loginAction'));
 				}
 			}

--- a/src/Controller/FavoritesController.php
+++ b/src/Controller/FavoritesController.php
@@ -8,13 +8,9 @@ use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use InvalidArgumentException;
-use TinyAuth\Controller\Component\AuthComponent;
-use TinyAuth\Controller\Component\AuthUserComponent;
 
 /**
  * @property \Favorites\Model\Table\FavoritesTable $Favorites
- * @property \TinyAuth\Controller\Component\AuthUserComponent $AuthUser
- * @property \TinyAuth\Controller\Component\AuthComponent $Auth
  */
 class FavoritesController extends AppController {
 
@@ -28,9 +24,9 @@ class FavoritesController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (class_exists(AuthUserComponent::class)) {
+		if (class_exists('TinyAuth\\Controller\\Component\\AuthUserComponent')) {
 			$this->loadComponent('TinyAuth.AuthUser');
-		} elseif (class_exists(AuthComponent::class)) {
+		} elseif (class_exists('TinyAuth\\Controller\\Component\\AuthComponent')) {
 			$this->loadComponent('TinyAuth.Auth');
 		}
 	}

--- a/src/Controller/LikesController.php
+++ b/src/Controller/LikesController.php
@@ -7,13 +7,9 @@ use Cake\Core\Configure;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
-use TinyAuth\Controller\Component\AuthComponent;
-use TinyAuth\Controller\Component\AuthUserComponent;
 
 /**
  * @property \Favorites\Model\Table\FavoritesTable $Favorites
- * @property \TinyAuth\Controller\Component\AuthUserComponent $AuthUser
- * @property \TinyAuth\Controller\Component\AuthComponent $Auth
  */
 class LikesController extends AppController {
 
@@ -27,9 +23,9 @@ class LikesController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (class_exists(AuthUserComponent::class)) {
+		if (class_exists('TinyAuth\\Controller\\Component\\AuthUserComponent')) {
 			$this->loadComponent('TinyAuth.AuthUser');
-		} elseif (class_exists(AuthComponent::class)) {
+		} elseif (class_exists('TinyAuth\\Controller\\Component\\AuthComponent')) {
 			$this->loadComponent('TinyAuth.Auth');
 		}
 	}

--- a/src/Controller/StarsController.php
+++ b/src/Controller/StarsController.php
@@ -7,13 +7,9 @@ use Cake\Core\Configure;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
-use TinyAuth\Controller\Component\AuthComponent;
-use TinyAuth\Controller\Component\AuthUserComponent;
 
 /**
  * @property \Favorites\Model\Table\FavoritesTable $Favorites
- * @property \TinyAuth\Controller\Component\AuthUserComponent $AuthUser
- * @property \TinyAuth\Controller\Component\AuthComponent $Auth
  */
 class StarsController extends AppController {
 
@@ -27,9 +23,9 @@ class StarsController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (class_exists(AuthUserComponent::class)) {
+		if (class_exists('TinyAuth\\Controller\\Component\\AuthUserComponent')) {
 			$this->loadComponent('TinyAuth.AuthUser');
-		} elseif (class_exists(AuthComponent::class)) {
+		} elseif (class_exists('TinyAuth\\Controller\\Component\\AuthComponent')) {
 			$this->loadComponent('TinyAuth.Auth');
 		}
 	}

--- a/src/View/Helper/AuthTrait.php
+++ b/src/View/Helper/AuthTrait.php
@@ -24,7 +24,10 @@ trait AuthTrait {
 		/** @var \App\View\AppView $view */
 		$view = $this->_View;
 		if ($view->helpers()->has('AuthUser')) {
-			return $view->AuthUser->user($userIdField);
+			$authUser = $view->helpers()->get('AuthUser');
+			if (method_exists($authUser, 'user')) {
+				return $authUser->user($userIdField);
+			}
 		}
 
 		return $view->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);


### PR DESCRIPTION
## Summary
- drop the optional TinyAuth dev dependency
- keep the plugin on its existing session fallback for auth-aware controller behavior
- avoid activating TinyAuth-specific code paths in tests when the package is not required

## Testing
- ./vendor/bin/phpcs --standard=phpcs.xml src tests
- ./vendor/bin/phpunit tests/TestCase/Controller/FavoritesControllerTest.php tests/TestCase/Controller/LikesControllerTest.php tests/TestCase/Controller/StarsControllerTest.php tests/TestCase/Controller/Admin/FavoritesControllerTest.php